### PR TITLE
v2.1.0: pixel-art mascot redesign and 429 rate limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ clu --token sk-ant-...
 |------|-------------|
 | `--dash` | Full-terminal dashboard with per-project stats |
 | `--data-dir PATH` | Additional `.claude` data directory (repeatable) |
-| `--refresh N` | API refresh interval in seconds (default: 30) |
+| `--refresh N` | API refresh interval in seconds (default: 60) |
 | `--no-resize` | Don't resize the terminal window |
 | `--token TOKEN` | Override OAuth token |
 
@@ -103,6 +103,16 @@ If you've used Claude Code at least once, it should just work.
 - `requests` - HTTP client
 
 ## Changelog
+
+### v2.1.0
+
+Mascot redesign and rate limit handling.
+
+- **New pixel-art mascot**: chunky background-colored sprite matching Claude Code's style — no more line-gap rendering artifacts
+- **Animated eyes**: mascot blinks with `^ ^` eyes periodically and during bounce animations
+- **Antenna**: cute violet `*|` antenna on top of the mascot
+- **429 rate limit handling**: respects `Retry-After` header from the API with exponential backoff
+- **Default refresh interval**: increased from 30s to 60s to reduce API rate limiting
 
 ### v2.0.0
 

--- a/clu.py
+++ b/clu.py
@@ -69,19 +69,33 @@ LIME    = "#a3e635"
 # Moods: chill (0-30%), cozy (30-50%), warm (50-70%), hot (70-90%), fire (90%+)
 
 def get_dash_creature(utilization, tick):
-    """Get a happy bouncy creature — always cheerful regardless of usage."""
+    """Get a happy bouncy creature — chunky pixel-art style."""
     bounce = (tick % 80) < 12  # bounce every 40 seconds
     frame = (tick % 80) // 3 if bounce else -1
 
+    # Background-colored spaces — no block chars, no line-gap stripes
+    ant  = f"      [{VIOLET}]*[/]"
+    stk  = f"      [{VIOLET}]|[/]"
+    top  = f"  [on {SKIN}]          [/]"
+    face  = f"  [on {SKIN}]  [/][on {DIM_D}] [{VIOLET} on {DIM_D}]*[/][on {DIM_D}]  [{VIOLET} on {DIM_D}]*[/][on {DIM_D}] [/][on {SKIN}]  [/]"
+    blink = f"  [on {SKIN}]  [/][on {DIM_D}] [{VIOLET} on {DIM_D}]^[/][on {DIM_D}]  [{VIOLET} on {DIM_D}]^[/][on {DIM_D}] [/][on {SKIN}]  [/]"
+    chin = f"  [on {SKIN}]          [/]"
+    body = f"   [on {SKIN}]        [/]"
+    legs = f"   [on {SKIN}]  [/]    [on {SKIN}]  [/]"
+
+    # Blink every ~10 seconds for 1 second
+    is_blink = (tick % 20) in (0, 1)
+    eyes = blink if is_blink else face
+
     if bounce and 0 <= frame < 4:
         frames = [
-            [f"",                f"   [{VIOLET}]*[/]",  f" [{SKIN}]┌─╨──┐[/]", f" [{SKIN}]│[/][{VIOLET}]▪[/] [{VIOLET}]▪[/][{SKIN}]│[/]", f" [{SKIN}]└┬──┬┘[/]", f" [{SKIN}] ╘══╛[/]"],
-            [f"   [{VIOLET}]✱[/]", f"   [{VIOLET}]![/]", f" [{SKIN}]┌────┐[/]", f" [{SKIN}]│[/][{VIOLET}]^[/] [{VIOLET}]^[/][{SKIN}]│[/]", f" [{SKIN}]└────┘[/]", f" [{SKIN}] ╱  ╲[/]"],
-            [f"   [{VIOLET}]✱[/]", f"   [{VIOLET}]|[/]", f" [{SKIN}]┌────┐[/]", f" [{SKIN}]│[/][{VIOLET}]⌒[/] [{VIOLET}]⌒[/][{SKIN}]│[/]", f" [{SKIN}]└────┘[/]", f""],
-            [f"   [{VIOLET}]*[/]", f"   [{VIOLET}]|[/]", f" [{SKIN}]┌────┐[/]", f" [{SKIN}]│[/][{VIOLET}]⌒[/] [{VIOLET}]⌒[/][{SKIN}]│[/]", f" [{SKIN}]└┬──┬┘[/]", f" [{SKIN}] │  │[/]"],
+            [ant, stk, top, eyes, chin, body, legs],
+            [f"", ant, top, blink, chin, body, f""],
+            [ant, stk, top, blink, chin, body, f""],
+            [f"", ant, top, eyes, chin, body, legs],
         ]
         return frames[frame]
-    return [f"   [{VIOLET}]*[/]", f"   [{VIOLET}]|[/]",  f" [{SKIN}]┌────┐[/]", f" [{SKIN}]│[/][{VIOLET}]⌒[/] [{VIOLET}]⌒[/][{SKIN}]│[/]", f" [{SKIN}]└┬──┬┘[/]", f" [{SKIN}] │  │[/]"]
+    return [ant, stk, top, eyes, chin, body, legs]
 
 
 def get_creature_speech(utilization, tick):
@@ -96,66 +110,29 @@ def get_creature_speech(utilization, tick):
 
 
 # ── Original widget creature (wider spacing for 46-col widget) ───────────────
+# Background-colored spaces — no block chars, no line-gap stripes
+_W_ANT   = f"          [{VIOLET}]*[/]"
+_W_STK   = f"          [{VIOLET}]|[/]"
+_W_TOP   = f"      [on {SKIN}]          [/]"
+_W_FACE  = f"      [on {SKIN}]  [/][on {DIM_D}] [{VIOLET} on {DIM_D}]*[/][on {DIM_D}]  [{VIOLET} on {DIM_D}]*[/][on {DIM_D}] [/][on {SKIN}]  [/]"
+_W_BLINK = f"      [on {SKIN}]  [/][on {DIM_D}] [{VIOLET} on {DIM_D}]^[/][on {DIM_D}]  [{VIOLET} on {DIM_D}]^[/][on {DIM_D}] [/][on {SKIN}]  [/]"
+_W_CHIN  = f"      [on {SKIN}]          [/]"
+_W_BODY  = f"       [on {SKIN}]        [/]"
+_W_LEGS  = f"       [on {SKIN}]  [/]    [on {SKIN}]  [/]"
+
 CREATURE_IDLE_WIDGET = [
-    [
-        f"          [{VIOLET}]*[/]",
-        f"          [{VIOLET}]|[/]",
-        f"        [{SKIN}]┌────┐[/]",
-        f"        [{SKIN}]│[/][{VIOLET}]▪[/] [{VIOLET}]▪[/][{SKIN}]│[/]",
-        f"        [{SKIN}]└┬──┬┘[/]",
-        f"        [{SKIN}] │  │[/]",
-    ],
+    [_W_ANT, _W_STK, _W_TOP, _W_FACE, _W_CHIN, _W_BODY, _W_LEGS],
+]
+
+CREATURE_BLINK_WIDGET = [
+    [_W_ANT, _W_STK, _W_TOP, _W_BLINK, _W_CHIN, _W_BODY, _W_LEGS],
 ]
 
 CREATURE_BOUNCE_WIDGET = [
-    [
-        f"",
-        f"          [{VIOLET}]*[/]",
-        f"        [{SKIN}]┌─╨──┐[/]",
-        f"        [{SKIN}]│[/][{VIOLET}]▪[/] [{VIOLET}]▪[/][{SKIN}]│[/]",
-        f"        [{SKIN}]└┬──┬┘[/]",
-        f"        [{SKIN}] ╘══╛[/]",
-    ],
-    [
-        f"          [{VIOLET}]*[/]",
-        f"          [{VIOLET}]|[/]",
-        f"        [{SKIN}]┌────┐[/]",
-        f"        [{SKIN}]│[/][{VIOLET}]^[/] [{VIOLET}]^[/][{SKIN}]│[/]",
-        f"        [{SKIN}]└────┘[/]",
-        f"        [{SKIN}] ╱  ╲[/]",
-    ],
-    [
-        f"          [{VIOLET}]✱[/]",
-        f"          [{VIOLET}]|[/]",
-        f"        [{SKIN}]┌────┐[/]",
-        f"        [{SKIN}]│[/][{VIOLET}]°[/] [{VIOLET}]°[/][{SKIN}]│[/]",
-        f"        [{SKIN}]└────┘[/]",
-        f"",
-    ],
-    [
-        f"          [{VIOLET}]✱[/]",
-        f"          [{VIOLET}]![/]",
-        f"        [{SKIN}]┌────┐[/]",
-        f"        [{SKIN}]│[/][{VIOLET}]⌒[/] [{VIOLET}]⌒[/][{SKIN}]│[/]",
-        f"        [{SKIN}]└────┘[/]",
-        f"",
-    ],
-    [
-        f"          [{VIOLET}]✱[/]",
-        f"          [{VIOLET}]|[/]",
-        f"        [{SKIN}]┌────┐[/]",
-        f"        [{SKIN}]│[/][{VIOLET}]°[/] [{VIOLET}]°[/][{SKIN}]│[/]",
-        f"        [{SKIN}]└────┘[/]",
-        f"",
-    ],
-    [
-        f"",
-        f"          [{VIOLET}]*[/]",
-        f"        [{SKIN}]┌─╨──┐[/]",
-        f"        [{SKIN}]│[/][{VIOLET}]▪[/] [{VIOLET}]▪[/][{SKIN}]│[/]",
-        f"        [{SKIN}]└┬──┬┘[/]",
-        f"        [{SKIN}] ╘══╛[/]",
-    ],
+    [_W_ANT, _W_STK, _W_TOP, _W_FACE,  _W_CHIN, _W_BODY, _W_LEGS],
+    [f"",    _W_ANT, _W_TOP, _W_BLINK, _W_CHIN, _W_BODY, f""],
+    [_W_ANT, _W_STK, _W_TOP, _W_BLINK, _W_CHIN, _W_BODY, f""],
+    [f"",    _W_ANT, _W_TOP, _W_FACE,  _W_CHIN, _W_BODY, _W_LEGS],
 ]
 
 BOUNCE_INTERVAL = 120
@@ -168,6 +145,9 @@ def get_creature_lines_widget(tick):
     if cycle_pos < bounce_total_ticks:
         frame_idx = cycle_pos // BOUNCE_FRAME_HOLD
         return CREATURE_BOUNCE_WIDGET[frame_idx]
+    # Blink every ~10 seconds for 1 second
+    elif (tick % 20) in (0, 1):
+        return CREATURE_BLINK_WIDGET[0]
     else:
         return CREATURE_IDLE_WIDGET[0]
 
@@ -534,6 +514,12 @@ def get_token():
 
 # ── API call ──────────────────────────────────────────────────────────────────
 
+class RateLimited(Exception):
+    """Raised on 429 with optional Retry-After seconds."""
+    def __init__(self, retry_after=None):
+        self.retry_after = retry_after
+        super().__init__(f"429 rate limited (retry after {retry_after}s)")
+
 def fetch_usage(token):
     """Hit Anthropic's oauth/usage endpoint. Returns dict or raises."""
     resp = requests.get(
@@ -544,6 +530,10 @@ def fetch_usage(token):
         },
         timeout=10,
     )
+    if resp.status_code == 429:
+        retry_after = resp.headers.get("Retry-After") or resp.headers.get("retry-after")
+        secs = int(retry_after) if retry_after and retry_after.isdigit() else None
+        raise RateLimited(secs)
     resp.raise_for_status()
     return resp.json()
 
@@ -1278,7 +1268,7 @@ def _setup_terminal(dash=False):
 
 # ── Main loop ─────────────────────────────────────────────────────────────────
 
-REFRESH_SECS = 30
+REFRESH_SECS = 60
 
 def main():
     global REFRESH_SECS
@@ -1348,6 +1338,7 @@ def main():
         local_data = parse_project_data(data_dirs)
         history = UsageHistory(max_samples=60)
         next_fetch = 0
+        backoff = REFRESH_SECS
         next_local_refresh = time.time() + 300
 
         with Live(
@@ -1365,8 +1356,14 @@ def main():
                         error_msg = None
                         last_ok   = datetime.now().strftime("%H:%M:%S")
                         next_fetch = now_ts + REFRESH_SECS
+                        backoff = REFRESH_SECS
                         # Record sample for live chart
                         history.record(api_data)
+                    except RateLimited as e:
+                        wait = e.retry_after or min(backoff * 2, 300)
+                        backoff = wait
+                        error_msg = f"rate limited (retry in {wait}s)"
+                        next_fetch = now_ts + wait
                     except requests.HTTPError as e:
                         error_msg = f"HTTP {e.response.status_code}"
                         next_fetch = now_ts + REFRESH_SECS
@@ -1396,6 +1393,7 @@ def main():
             sys.stdout.flush()
 
         next_fetch = 0
+        backoff = REFRESH_SECS
 
         with Live(make_widget(api_data, last_ok, error_msg, tick),
                   console=console,
@@ -1410,6 +1408,12 @@ def main():
                         error_msg = None
                         last_ok   = datetime.now().strftime("%H:%M:%S")
                         next_fetch = now_ts + REFRESH_SECS
+                        backoff = REFRESH_SECS
+                    except RateLimited as e:
+                        wait = e.retry_after or min(backoff * 2, 300)
+                        backoff = wait
+                        error_msg = f"rate limited (retry in {wait}s)"
+                        next_fetch = now_ts + wait
                     except requests.HTTPError as e:
                         error_msg = f"HTTP {e.response.status_code}"
                         next_fetch = now_ts + REFRESH_SECS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clu-widget"
-version = "2.0.0"
+version = "2.1.0"
 description = "Claude Usage Monitor — terminal widget and dashboard for tracking Claude Code usage"
 readme = "README.md"
 license = "MIT"
@@ -32,9 +32,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/hsantanna/clu"
-Repository = "https://github.com/hsantanna/clu"
-Issues = "https://github.com/hsantanna/clu/issues"
+Homepage = "https://github.com/hsantanna88/clu-widget"
+Repository = "https://github.com/hsantanna88/clu-widget"
+Issues = "https://github.com/hsantanna88/clu-widget/issues"
 
 [project.scripts]
 clu = "clu:main"


### PR DESCRIPTION
## Summary

- **Pixel-art mascot redesign**: replaced box-drawing character robot with chunky background-colored sprite matching Claude Code's welcome screen style. Uses `[on COLOR]` background spaces instead of block characters (`█▄▀`) to eliminate terminal line-gap rendering artifacts.
- **Animated eyes**: mascot blinks with `^ ^` eyes periodically and during bounce animations. Normal eyes are `* *` on a dark visor strip.
- **Cute antenna**: violet `*|` antenna on top of the mascot.
- **429 rate limit handling**: dedicated `RateLimited` exception that reads and respects the `Retry-After` header from Anthropic's API, with exponential backoff (capped at 300s).
- **Default refresh interval**: increased from 30s to 60s to reduce API rate limiting.

## Changes

| File | What changed |
|------|-------------|
| `clu.py` | Mascot rewrite (dashboard + widget), `RateLimited` exception, backoff logic in both event loops |
| `pyproject.toml` | Version bump to 2.1.0 |
| `README.md` | Updated default refresh docs, added v2.1.0 changelog entry |

## Test plan

- [ ] Run `clu` (widget mode) — verify mascot renders with no line-gap stripes
- [ ] Verify `^ ^` blink animation triggers every ~10 seconds
- [ ] Verify antenna `*|` appears above mascot
- [ ] Run `clu --dash` — verify dashboard mascot matches
- [ ] Simulate 429 — confirm backoff message and recovery
- [ ] Verify `pip install .` works and `clu` entry point launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)