### PR TITLE
v2.1.1: clean exit on Ctrl+C for pip/pipx installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ If you've used Claude Code at least once, it should just work.
 
 ## Changelog
 
+### v2.1.1
+
+Clean exit on Ctrl+C — no more traceback or errno 130 when installed via pip/pipx.
+
 ### v2.1.0
 
 Mascot redesign and rate limit handling.

--- a/clu.py
+++ b/clu.py
@@ -1331,6 +1331,12 @@ def main():
         ))
         sys.exit(1)
 
+    try:
+        _run_loop(args, token, api_data, last_ok, error_msg, tick, data_dirs, data_dirs_info)
+    except KeyboardInterrupt:
+        _cleanup()
+
+def _run_loop(args, token, api_data, last_ok, error_msg, tick, data_dirs, data_dirs_info):
     if args.dash:
         _setup_terminal(dash=True)
         console = Console(highlight=False)
@@ -1427,8 +1433,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        _cleanup()
-        print()  # clean exit
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clu-widget"
-version = "2.1.0"
+version = "2.1.1"
 description = "Claude Usage Monitor — terminal widget and dashboard for tracking Claude Code usage"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Move `KeyboardInterrupt` handler inside `main()` so Ctrl+C exits cleanly regardless of entry point (pip, pipx, or direct `python clu.py`)
- Previously the handler only lived in the `if __name__ == "__main__"` block, so pip/pipx installs showed a traceback and errno 130

## Changes

| File | What changed |
|------|-------------|
| `clu.py` | Extract `_run_loop()`, wrap with try/except `KeyboardInterrupt` inside `main()` |
| `pyproject.toml` | Version bump to 2.1.1 |
| `README.md` | Added v2.1.1 changelog entry |

## Test plan

- [ ] `pip install .` then `clu` → Ctrl+C → clean exit, no traceback, `echo $?` returns 0
- [ ] `python clu.py` → Ctrl+C → same clean exit
- [ ] `clu --dash` → Ctrl+C → same clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)