### PR TITLE
v2.2.1: dynamic version display

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ If you've used Claude Code at least once, it should just work.
 
 ## Changelog
 
+### v2.2.1
+
+Version display now reads from package metadata instead of being hardcoded.
+
 ### v2.2.0
 
 Dashboard UX improvements and smarter project naming.

--- a/clu.py
+++ b/clu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-clu — Claude Usage Monitor 2.0
+clu — Claude Usage Monitor
 
 Widget mode (default):
     clu                          # cute animated widget
@@ -24,6 +24,12 @@ import atexit
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from collections import defaultdict
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("clu-widget")
+except Exception:
+    __version__ = "dev"
 
 try:
     import requests
@@ -901,7 +907,7 @@ def make_dashboard(api_data, local_data, last_ok, error_msg, tick, data_dirs_inf
     hero_panel = Panel(
         hero_content,
         title=Text.from_markup(
-            f"[bold {AMBER}]◆[/] [bold {WHITE}]clu[/] [bold {VIOLET}]2.0[/]"
+            f"[bold {AMBER}]◆[/] [bold {WHITE}]clu[/] [bold {VIOLET}]{__version__}[/]"
         ),
         border_style=VIOLET_D,
         box=box.ROUNDED,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clu-widget"
-version = "2.2.0"
+version = "2.2.1"
 description = "Claude Usage Monitor — terminal widget and dashboard for tracking Claude Code usage"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Version in dashboard title now reads from package metadata instead of hardcoded "2.0"
- Shows actual installed version (e.g. "clu 2.2.1")

🤖 Generated with [Claude Code](https://claude.com/claude-code)