### PR TITLE
v2.2.2: faster cold-start recovery on rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ If you've used Claude Code at least once, it should just work.
 
 ## Changelog
 
+### v2.2.2
+
+Faster cold-start recovery — first rate-limit retry is now 10s instead of 60-120s.
+
 ### v2.2.1
 
 Version display now reads from package metadata instead of being hardcoded.

--- a/clu.py
+++ b/clu.py
@@ -1402,7 +1402,7 @@ def _run_loop(args, token, api_data, last_ok, error_msg, tick, data_dirs, data_d
         local_data = parse_project_data(data_dirs)
         history = UsageHistory(max_samples=60)
         next_fetch = 0
-        backoff = REFRESH_SECS
+        backoff = 5
         next_local_refresh = time.time() + 300
 
         with Live(
@@ -1466,7 +1466,7 @@ def _run_loop(args, token, api_data, last_ok, error_msg, tick, data_dirs, data_d
             sys.stdout.flush()
 
         next_fetch = 0
-        backoff = REFRESH_SECS
+        backoff = 5
 
         with Live(make_widget(api_data, last_ok, error_msg, tick),
                   console=console,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clu-widget"
-version = "2.2.1"
+version = "2.2.2"
 description = "Claude Usage Monitor — terminal widget and dashboard for tracking Claude Code usage"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Initial backoff starts at 5s instead of 60s
- First 429 retries in ~10s rather than 60-120s
- Escalates on repeated failures (10→20→40→80→120s cap)
- Resets on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)